### PR TITLE
Import topologically regularized autoencoder

### DIFF
--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -4,8 +4,8 @@ from tqdm import tqdm
 from torch.utils.data import DataLoader
 from torchvision.utils import save_image
 
-from src.evaluation.utils import get_space
-from src.visualization import visualize_latents
+from evaluation.utils import get_space
+from visualization import visualize_latents
 
 # Hush the linter, child callbacks will always have different parameters than
 # the overwritten method of the parent class. Further kwargs will mostly be an

--- a/src/get_all_spaces.py
+++ b/src/get_all_spaces.py
@@ -6,12 +6,12 @@ sys.path.append('../')
 
 import torch
 
-from src.datasets import CIFAR
-from src.datasets import FashionMNIST
-from src.datasets import MNIST
-from src.datasets import Spheres
+from datasets import CIFAR
+from datasets import FashionMNIST
+from datasets import MNIST
+from datasets import Spheres
 
-from src.evaluation.utils import get_space
+from evaluation.utils import get_space
 
 
 def load_data(name):

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,7 +1,7 @@
 """All models."""
-from .approx_based import TopologicallyRegularizedAutoencoder
-from .vanilla import ConvolutionalAutoencoderModel, VanillaAutoencoderModel
-from .competitors import Isomap, PCA, TSNE, UMAP
+from models.approx_based import TopologicallyRegularizedAutoencoder
+from models.vanilla import ConvolutionalAutoencoderModel, VanillaAutoencoderModel
+from models.competitors import Isomap, PCA, TSNE, UMAP
 
 __all__ = [
     'ConvolutionalAutoencoderModel',

--- a/src/models/approx_based.py
+++ b/src/models/approx_based.py
@@ -3,9 +3,9 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from src.topology import PersistentHomologyCalculation #AlephPersistenHomologyCalculation, \
-from src.models import submodules
-from src.models.base import AutoencoderModel
+from topology import PersistentHomologyCalculation #AlephPersistenHomologyCalculation, \
+from models import submodules
+from models.base import AutoencoderModel
 
 
 class TopologicallyRegularizedAutoencoder(AutoencoderModel):

--- a/src/models/submodules.py
+++ b/src/models/submodules.py
@@ -5,7 +5,7 @@ import torch.nn as nn
 from torch.distributions import Normal
 import torch.nn.functional as F
 
-from .base import AutoencoderModel
+from models.base import AutoencoderModel
 # Hush the linter: Warning W0221 corresponds to a mismatch between parent class
 # method signature and the child class
 # pylint: disable=W0221

--- a/src/models/vanilla.py
+++ b/src/models/vanilla.py
@@ -1,8 +1,8 @@
 """Vanilla models."""
 import torch.nn as nn
 
-from src.models import submodules
-from .base import AutoencoderModel
+from models import submodules
+from models.base import AutoencoderModel
 
 
 class ConvolutionalAutoencoderModel(submodules.ConvolutionalAutoencoder):


### PR DESCRIPTION
Adjusted import paths across the codebase to resolve `ImportError` when scripts are run from different directories.

The original imports, such as `from src.topology`, caused `ImportError` when scripts were executed from outside the `src` directory or when `src` was already in `sys.path`. This PR changes these to relative imports (e.g., `from topology`) or absolute imports within the package structure (e.g., `from models.submodules`) to ensure correct module resolution.

---
<a href="https://cursor.com/background-agent?bcId=bc-db7ee02b-e786-4b71-8d9f-e2d6cca0da81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-db7ee02b-e786-4b71-8d9f-e2d6cca0da81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

